### PR TITLE
Add possibility to specify which modes to allow in simulate_atc_track

### DIFF
--- a/matlab/simulate_atc_track.m
+++ b/matlab/simulate_atc_track.m
@@ -1,4 +1,8 @@
-function [X, Z, a] = simulate_atc_track(Ts, K, q, r, init, PD, lambda, theCase)
+function [X, Z, a] = simulate_atc_track(Ts, K, q, r, init, PD, lambda, theCase, cv, ct)
+
+if (~(cv || ct))
+    throw(MException('meme:meme','Either cv or ct must be true'));
+end
 
 if theCase
     rng('default');
@@ -43,6 +47,9 @@ X(:,1) = xzero;
 z(:,1) = h(X(:,1)) + sqrtR*randn(m,1);
 
 s = 1;
+if (ct && ~cv)
+    s = 2;
+end
 
 for k=2:K
     maxSpeedRatio = (X(3, k)^2 + X(4, k)^2)/(maxSpeed^2);
@@ -54,18 +61,20 @@ for k=2:K
         X(5, k) = maxTurn * sign(X(5));
     end
     
-    if k == 25  %First turn
-        X(5, k - 1) = (pi/2)/(18 * Ts);
-        s = 2;
-    elseif k == 43 %Straight movement
-        X(5, k - 1) = 0;
-        s = 1;
-    elseif k == 68 % second turn
-        X(5, k - 1) = (-2*pi/3)/(15*Ts);
-        s = 2;
-    elseif k == 74 %Straight movement
-        X(5, k - 1) = 0;
-        s = 1;
+    if (cv && ct)
+        if k == 25  %First turn
+            X(5, k - 1) = (pi/2)/(18 * Ts);
+            s = 2;
+        elseif k == 43 %Straight movement
+            X(5, k - 1) = 0;
+            s = 1;
+        elseif k == 68 % second turn
+            X(5, k - 1) = (-2*pi/3)/(15*Ts);
+            s = 2;
+        elseif k == 74 %Straight movement
+            X(5, k - 1) = 0;
+            s = 1;
+        end
     end
     
     X(:,k) = models{s}.f(X(:, k-1), Ts) + models{s}.sqrtQ(X(:, k - 1), Ts) * randn(n,1);

--- a/matlab/task2.m
+++ b/matlab/task2.m
@@ -13,7 +13,7 @@ else
     % detection and false alarm
     PDtrue = 0.9;
     lambdatrue = 1e-4;
-    [Xgt, Z, a] = simulate_atc_track(Ts, K, q, r, init, PDtrue, lambdatrue, false);
+    [Xgt, Z, a] = simulate_atc_track(Ts, K, q, r, init, PDtrue, lambdatrue, false, true, true);
 end
 
 


### PR DESCRIPTION
The final two arguments to `simulate_atc_track` are now booleans specifying if the CV and/or the CT mode should be enabled.

The following configurations are allowed:
* CV and no CT
* no CV and CT
* CV and CT

Calling the function with no CV and no CT will throw an exception. 

### CV-only track
![image](https://user-images.githubusercontent.com/5937246/66813770-af029d00-ef35-11e9-9d47-483250b1b417.png)

### CT-only track
![image](https://user-images.githubusercontent.com/5937246/66813993-1ddff600-ef36-11e9-8a64-f878ca3508bf.png)

